### PR TITLE
Fix for Title Alignment caught after Deployment

### DIFF
--- a/signin/templates/signin/signin.html
+++ b/signin/templates/signin/signin.html
@@ -8,7 +8,7 @@
 <div class="container">
     <div class="row">
         <aside class="col-sm-5" style="margin: auto">
-            <h1 class="mt-2">nycCivilServiceJobs</h1>
+            <h1 class="mt-2" style="text-align:center">nycCivilServiceJobs</h1>
         </aside>
     </div>
 </div>


### PR DESCRIPTION
Sign in Page Title Alignment Fix